### PR TITLE
Update build script to be compatible with latest python and emsdk

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
     grunt.initConfig({
         exec: {
             emscripten: {
-                cmd: 'python build.py'
+                cmd: 'python3 build.py'
             }
         },
         concat: {

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ for (var i = 0; i &lt; ehdr.shnum; i++) {
 ## Building
 To build the Libelf.js library, clone the *master* branch of this repository, and do the following:
 
-1. Install the latest [Python 2.x (64-bit)](https://www.python.org/downloads/), [CMake](http://www.cmake.org/download/) and the [Emscripten SDK](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html). Follow the respective instructions and make sure all environment variables are configured correctly. Under Windows [MinGW](http://www.mingw.org/) (specifically *mingw32-make*) is required.
+1. Install the latest [Python 3.8+](https://www.python.org/downloads/), [CMake](http://www.cmake.org/download/) and the [Emscripten SDK 2.0.21+](https://emscripten.org/docs/getting_started/downloads.html). Follow the respective instructions and make sure all environment variables are configured correctly. Under Windows [MinGW](http://www.mingw.org/) (specifically *mingw32-make*) is required.
 
-2. Install the development dependencies with: `npm install`.
+2. Install the development dependencies with: `npm install --also=dev`.
 
-3. Finally, build the source with: `grunt build`.
+3. Install grunt with: `npm install -g grunt`
+
+4. Finally, build the source with: `grunt build`.


### PR DESCRIPTION
The latest emsdk introduced some deprecations, so we need to make the build script compatible with it.
Python 2.x has reached its end of life. We need to switch to Python3